### PR TITLE
fixed!

### DIFF
--- a/UseSwaggerFromWebApplication/.config/dotnet-tools.json
+++ b/UseSwaggerFromWebApplication/.config/dotnet-tools.json
@@ -1,0 +1,12 @@
+{
+    "version": 1,
+    "isRoot": true,
+    "tools": {
+      "microsoft.dotnet-openapi": {
+        "version": "3.1.7",
+        "commands": [
+          "dotnet-openapi"
+        ]
+      }
+    }
+  }

--- a/UseSwaggerFromWebApplication/Program.cs
+++ b/UseSwaggerFromWebApplication/Program.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Net.Http;
 
 namespace UseSwaggerFromWebApplication
 {
@@ -6,7 +7,15 @@ namespace UseSwaggerFromWebApplication
     {
         static void Main(string[] args)
         {
-            Console.WriteLine("Hello World!");
+            var baseUrl = "http://localhost:5000";
+            var httpClient = new HttpClient();
+            var apiClient = new WebApplication.WebApplicationClient(baseUrl, httpClient);
+            var result = apiClient.GetAsync().Result;
+
+            foreach (var item in result)
+            {
+                Console.WriteLine($"Weather is {item.Summary} at {item.TemperatureF}");
+            }
         }
     }
 }

--- a/UseSwaggerFromWebApplication/UseSwaggerFromWebApplication.csproj
+++ b/UseSwaggerFromWebApplication/UseSwaggerFromWebApplication.csproj
@@ -3,6 +3,31 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp3.1</TargetFramework>
+    <AssemblyName>WebApplication</AssemblyName>
+    <RootNamespace>WebApplication</RootNamespace>
   </PropertyGroup>
+
+  <ItemGroup>
+    <Content Include=".config\dotnet-tools.json" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <OpenApiReference Include="..\WebApplication\bin\Debug\netcoreapp3.1\WebApplication.json">
+      <CodeGenerator>NSwagCSharp</CodeGenerator>
+      <Link>OpenAPIs\WebApplication.json</Link>
+    </OpenApiReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.ApiDescription.Client" Version="3.0.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
+    <PackageReference Include="NSwag.ApiDescription.Client" Version="13.0.5">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
 
 </Project>

--- a/WebApplication/.config/dotnet-tools.json
+++ b/WebApplication/.config/dotnet-tools.json
@@ -1,0 +1,12 @@
+{
+    "version": 1,
+    "isRoot": true,
+    "tools": {
+      "swashbuckle.aspnetcore.cli": {
+        "version": "5.6.3",
+        "commands": [
+          "swagger"
+        ]
+      }
+    }
+  }

--- a/WebApplication/Startup.cs
+++ b/WebApplication/Startup.cs
@@ -9,6 +9,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
+using Microsoft.OpenApi.Models;
 
 namespace WebApplication
 {
@@ -27,7 +28,10 @@ namespace WebApplication
             services.AddControllers();
 
             // Register the Swagger services
-            services.AddSwaggerDocument();
+            services.AddSwaggerGen(c =>
+            {
+                c.SwaggerDoc("v1", new OpenApiInfo { Title = "My API", Version = "v1" });
+            });
             services.AddMvc();
         }
 
@@ -37,6 +41,8 @@ namespace WebApplication
             if (env.IsDevelopment())
             {
                 app.UseDeveloperExceptionPage();
+                app.UseSwagger();
+                app.UseSwaggerUI(c => c.SwaggerEndpoint("/swagger/v1/swagger.json", "My API"));
             }
 
             app.UseRouting();
@@ -47,9 +53,6 @@ namespace WebApplication
             {
                 endpoints.MapControllers();
             });
-
-            app.UseOpenApi();
-            app.UseSwaggerUi3();
         }
     }
 }

--- a/WebApplication/WebApplication.csproj
+++ b/WebApplication/WebApplication.csproj
@@ -5,7 +5,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NSwag.AspNetCore" Version="13.8.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="swashbuckle.aspnetcore" Version="5.6.3" />
   </ItemGroup>
 
 

--- a/WebApplication/WebApplication.csproj
+++ b/WebApplication/WebApplication.csproj
@@ -2,14 +2,20 @@
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
+    <AssemblyName>WebApplication</AssemblyName>
+		<RootNamespace>WebApplication</RootNamespace>
   </PropertyGroup>
 
   <ItemGroup>
-  </ItemGroup>
+		<Content Include=".config\dotnet-tools.json" />
+	</ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="swashbuckle.aspnetcore" Version="5.6.3" />
   </ItemGroup>
 
+  <Target Name="Generate OpenAPI Specification Document" AfterTargets="Build">
+		<Exec Command="dotnet swagger tofile --serializeasv2 --output $(OutputPath)$(AssemblyName).json $(OutputPath)$(AssemblyName).dll v1" />
+	</Target>
 
 </Project>


### PR DESCRIPTION
This PR includes:

1. Changes to the API project to use Swashbuckle instead of NSwag, as I couldn't get NSwag to build on non-Windows machine. This may not be an issue for others but I couldn't compile. 
2. Added support to generate the Swagger file at build-time
3. Added support to generate the client into the console app project
4. Added code to the console app project to call the API via the generated code 